### PR TITLE
feat: Add support of `Qwen` and `OpenAI` models

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,12 +1,31 @@
 # API配置
-API_TYPE="ollama"  # 可选值: "deepseek" 或 "ollama"
+API_TYPE="qwen"  # Supported values: "deepseek", "qwen", "openai", "ollama"
 
 # DeepSeek API配置
 DEEPSEEK_API_KEY=""
 
-# Ollama API配置
-OLLAMA_API_URL="http://localhost:11434/api/chat"  # Ollama API地址
-OLLAMA_MODEL="qwen2.5-coder:14b"  # Ollama模型名称
+# OPENAI
+OPENAI_API_KEY=""
+
+# QWEN
+QWEN_API_KEY=""
+
+# OLLAMA
+OLLAMA_API_KEY=""
+OLLAMA_API_URL="http://localhost:11434/v1"  # Ollama API地址
+
+
+## 可选参数
+
+## OPENAI 第三方API地址
+# OPENAI_API_URL="https://api.openai.com/v1/"
+
+## MODEL
+# DEEPSEEK_MODEL=""
+# QWEN_MODEL=""
+# OPENAI_MODEL=""
+# OLLAMA_MODEL=""
+
 
 # 主题配色方案
 THEMES = {

--- a/config.py.example
+++ b/config.py.example
@@ -1,12 +1,29 @@
 # API配置
-API_TYPE="deepseek"  # 可选值: "deepseek" 或 "ollama"
+API_TYPE="qwen"  # Supported values: "deepseek", "qwen", "openai", "ollama"
 
 # DeepSeek API配置
 DEEPSEEK_API_KEY=""
 
-# Ollama API配置
-OLLAMA_API_URL="http://localhost:11434/api/chat"  # Ollama API地址
-OLLAMA_MODEL="deepseek-coder"  # Ollama模型名称
+# OPENAI
+OPENAI_API_KEY=""
+
+# QWEN
+QWEN_API_KEY=""
+
+# OLLAMA
+OLLAMA_API_KEY=""
+OLLAMA_API_URL="http://localhost:11434/v1"  # Ollama API地址
+
+
+## 可选参数
+## OPENAI 第三方API地址
+# OPENAI_API_URL="https://api.openai.com/v1/"
+## MODEL
+# DEEPSEEK_MODEL=""
+# QWEN_MODEL=""
+# OPENAI_MODEL=""
+# OLLAMA_MODEL=""
+
 
 # 主题配色方案
 THEMES = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyQt5==5.15.11
 PyQt5_sip==12.15.0
 Requests==2.32.3
+openai==1.16.1


### PR DESCRIPTION
### DeepSeekSelfTool.py:
- Refactored the `APIAdapter` class to support multiple API types (deepseek, qwen, openai, ollama).
- Introduced `_send_request` and `_clean_ollama_response` methods for handling API requests.

### config.py and config.py.example:
- Updated API_TYPE comment to "Supported values: deepseek, qwen, openai, ollama".
- Added API key placeholders for openai, qwen, and ollama.
- Added optional parameters for API URLs and models.

### requirements.txt:
- Added `openai==1.16.1`.